### PR TITLE
Make Element Desktop send telegram sticker info

### DIFF
--- a/sticker/stickerimport.py
+++ b/sticker/stickerimport.py
@@ -45,7 +45,7 @@ def add_meta(document: Document, info: matrix.StickerInfo, pack: StickerSetFull)
         if isinstance(attr, DocumentAttributeSticker):
             info["body"] = attr.alt
     info["id"] = f"tg-{document.id}"
-    info["net.maunium.telegram.sticker"] = {
+    info["info"]["net.maunium.telegram.sticker"] = {
         "pack": {
             "id": str(pack.set.id),
             "short_name": pack.set.short_name,
@@ -73,7 +73,7 @@ async def reupload_pack(client: TelegramClient, pack: StickerSetFull, output_dir
     try:
         with util.open_utf8(pack_path) as pack_file:
             existing_pack = json.load(pack_file)
-            already_uploaded = {int(sticker["net.maunium.telegram.sticker"]["id"]): sticker
+            already_uploaded = {int(sticker["info"]["net.maunium.telegram.sticker"]["id"]): sticker
                                 for sticker in existing_pack["stickers"]}
             print(f"Found {len(already_uploaded)} already reuploaded stickers")
     except FileNotFoundError:
@@ -97,7 +97,7 @@ async def reupload_pack(client: TelegramClient, pack: StickerSetFull, output_dir
             # If there was no sticker metadata, use the first emoji we find
             if doc["body"] == "":
                 doc["body"] = sticker.emoticon
-            doc["net.maunium.telegram.sticker"]["emoticons"].append(sticker.emoticon)
+            doc["info"]["net.maunium.telegram.sticker"]["emoticons"].append(sticker.emoticon)
 
     with util.open_utf8(pack_path, "w") as pack_file:
         json.dump({

--- a/web/src/widget-api.js
+++ b/web/src/widget-api.js
@@ -47,6 +47,11 @@ window.onmessage = event => {
 }
 
 export function sendSticker(content) {
+	if (content["info"]["net.maunium.telegram.sticker"] === undefined) {
+		// Old sticker, move the property to its new location
+		content["info"]["net.maunium.telegram.sticker"] = content["net.maunium.telegram.sticker"];
+		delete content["net.maunium.telegram.sticker"];
+	}
 	const data = {
 		content: { ...content },
 		// `name` is for Element Web (and also the spec)


### PR DESCRIPTION
Element Desktop removes additional properties in the sticker info, but not the media info. Element Android removes them in both currently. This commit moves the net.maunium.telegram.sticker property to the media info. This can be combined with a change to mautrix-telegram that bridges telegram-imported matrix stickers to matrix stickers.